### PR TITLE
Minor suggestions for parallel module

### DIFF
--- a/content/week01/practices.md
+++ b/content/week01/practices.md
@@ -272,7 +272,7 @@ get_rect_area(x1, y1, x2, y2)
 ```
 
 Someone calling the function could easily make a mistake:
-`get_rect_area(x1, x2, y1, y1)` for example. However, if you bundle this:
+`get_rect_area(x1, x2, y1, y2)` for example. However, if you bundle this:
 
 ```python
 def get_rect_area(point_1, point_2): ...  # does stuff

--- a/content/week11/piexample/asyncpi.py
+++ b/content/week11/piexample/asyncpi.py
@@ -13,22 +13,23 @@ async def timer():
     print(f"Took {time.monotonic() - start:.3}s to run")
 
 
-def pi_each(trials: int) -> None:
+async def pi_async(trials: int) -> float:
     Ncirc = 0
     rand = random.Random()
 
-    for _ in range(trials):
+    for trial in range(trials):
         x = rand.uniform(-1, 1)
         y = rand.uniform(-1, 1)
 
         if x * x + y * y <= 1:
             Ncirc += 1
 
+        # yield to event loop every 1000 iterations
+        # This allows other asyncs to do their job
+        if trial % 1000 == 0:
+            await asyncio.sleep(0)
+
     return 4.0 * (Ncirc / trials)
-
-
-async def pi_async(trials: int):
-    return await asyncio.to_thread(pi_each, trials)
 
 
 @timer()

--- a/content/week11/piexample/asyncpi_thread.py
+++ b/content/week11/piexample/asyncpi_thread.py
@@ -1,0 +1,45 @@
+import contextlib
+import random
+import statistics
+import threading
+import time
+import asyncio
+
+
+@contextlib.asynccontextmanager
+async def timer():
+    start = time.monotonic()
+    yield
+    print(f"Took {time.monotonic() - start:.3}s to run")
+
+
+def pi_each(trials: int) -> None:
+    Ncirc = 0
+    rand = random.Random()
+
+    for _ in range(trials):
+        x = rand.uniform(-1, 1)
+        y = rand.uniform(-1, 1)
+
+        if x * x + y * y <= 1:
+            Ncirc += 1
+
+    return 4.0 * (Ncirc / trials)
+
+
+async def pi_async(trials: int):
+    return await asyncio.to_thread(pi_each, trials)
+
+
+@timer()
+async def pi_all(trials: int, threads: int) -> float:
+    async with asyncio.TaskGroup() as tg:
+        tasks = [tg.create_task(pi_async(trials // threads)) for _ in range(threads)]
+    return statistics.mean(t.result() for t in tasks)
+
+
+def pi(trials: int, threads: int) -> float:
+    return asyncio.run(pi_all(trials, threads))
+
+
+print(f"{pi(10_000_000, 10)=}")


### PR DESCRIPTION
Other than the minor verbiage changes (one unrelated to week11 that I noticed earlier), the main suggestion here is that I think we're introducing threads with async a little too soon, before the "regular" async stuff has been introduced. So I changed the existing `asyncpi.py` to not use threads, and moved your existing example to `asyncpi_thread.py`. If acceptable, feel free to change the wording to suit your needs.

I had no idea about `InterpreterPoolExecutor` and didn't realize that `if __name__ == "__main__"` check is necessary for the `spawn` method, so this was very helpful!